### PR TITLE
bug: watchOS wrongly completing ongoing series

### DIFF
--- a/AniHyouShou Watch App/MediaList/MediaListViewModel.swift
+++ b/AniHyouShou Watch App/MediaList/MediaListViewModel.swift
@@ -5,7 +5,6 @@
 //  Created by Axel Lopez on 18/05/2024.
 //
 
-import SwiftUI
 import Foundation
 import AniListAPI
 

--- a/AniHyouShou Watch App/MediaList/UpdateMediaEntryView.swift
+++ b/AniHyouShou Watch App/MediaList/UpdateMediaEntryView.swift
@@ -39,8 +39,8 @@ struct UpdateMediaEntryView: View {
             )
             .tint(Color(hex: entry.media?.coverImage?.color))
         }
-        .onChange(of: viewModel.shouldDismiss){ shouldDismiss in
-            if shouldDismiss{
+        .onChange(of: viewModel.shouldDismiss) { shouldDismiss in
+            if shouldDismiss {
                 dismiss()
             }
         }

--- a/AniHyouShou Watch App/MediaList/UpdateMediaEntryView.swift
+++ b/AniHyouShou Watch App/MediaList/UpdateMediaEntryView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import AniListAPI
 
 struct UpdateMediaEntryView: View {
+    @Environment(\.dismiss) var dismiss
 
     let entry: ShouUserMediaList
     @ObservedObject var viewModel: MediaListViewModel
@@ -37,6 +38,11 @@ struct UpdateMediaEntryView: View {
                 }
             )
             .tint(Color(hex: entry.media?.coverImage?.color))
+        }
+        .onChange(of: viewModel.shouldDismiss){ shouldDismiss in
+            if shouldDismiss{
+                dismiss()
+            }
         }
         .navigationBarTitleDisplayMode(.inline)
     }


### PR DESCRIPTION
Fixes #49 

Before this PR when the state of a media was changed nothing happened (the numbers did not change) in the watchOS app, because of this the user could thing that the action was not completed or something went wrong. 
I made it so that the UpdateMediaEntryView closes when this is the case, but the view could also be left open and just update the chapter's quantity so that the user knows it worked.