### PR TITLE
fix: #43 anime list 'all' title localisation

### DIFF
--- a/AniHyou/Screens/MediaList/Views/MediaListView.swift
+++ b/AniHyou/Screens/MediaList/Views/MediaListView.swift
@@ -115,7 +115,7 @@ struct MediaListView: View {
         } else if let listName = viewModel.selectedListName {
             return listName
         } else {
-            return "All"
+            return String(localized: "All")
         }
     }
     


### PR DESCRIPTION
## Corrected media list "All" localisation to fix #43 

`Screens/MediaList/Views/MediaListView.swift:118`
```
                    } else if let listName = viewModel.selectedListName {
            return listName
        } else {
-           return "All"
+           return String(localized: "All")
        }
    }
```