### PR TITLE
Feat/54 write reviews

### DIFF
--- a/AniHyou.xcodeproj/project.pbxproj
+++ b/AniHyou.xcodeproj/project.pbxproj
@@ -341,6 +341,8 @@
 		48FC94812868C0F400C87F56 /* MediaChartListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FC94802868C0F400C87F56 /* MediaChartListView.swift */; };
 		48FFC8BC2E10969900831B8E /* AniHyou.icon in Resources */ = {isa = PBXBuildFile; fileRef = 48FFC8BA2E10969900831B8E /* AniHyou.icon */; };
 		84734AE62A7DF658000BD9E6 /* MediaListRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84734AE52A7DF658000BD9E6 /* MediaListRepository.swift */; };
+		94970573302BBA1D006A5D9B /* WriteReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9497056B302BBA1D006A5D9B /* WriteReviewViewModel.swift */; };
+		94970575302BBA1D006A5D9B /* WriteReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9497056F302BBA1D006A5D9B /* WriteReviewView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -770,6 +772,8 @@
 		48FC94802868C0F400C87F56 /* MediaChartListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaChartListView.swift; sourceTree = "<group>"; };
 		48FFC8BA2E10969900831B8E /* AniHyou.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AniHyou.icon; sourceTree = "<group>"; };
 		84734AE52A7DF658000BD9E6 /* MediaListRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaListRepository.swift; sourceTree = "<group>"; };
+		9497056B302BBA1D006A5D9B /* WriteReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteReviewViewModel.swift; sourceTree = "<group>"; };
+		9497056F302BBA1D006A5D9B /* WriteReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteReviewView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -1871,6 +1875,7 @@
 			isa = PBXGroup;
 			children = (
 				484A6D6E28772D8C0044C34A /* ReviewDetailsViewModel.swift */,
+				9497056B302BBA1D006A5D9B /* WriteReviewViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -1880,6 +1885,7 @@
 			children = (
 				484A6D68287481500044C34A /* ReviewDetailsView.swift */,
 				484A6D63287480FB0044C34A /* ReviewItemView.swift */,
+				9497056F302BBA1D006A5D9B /* WriteReviewView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2338,6 +2344,8 @@
 				4832B02C285F35E200E79D27 /* SwiftUIUtils.swift in Sources */,
 				48A1A8F32A39861C00ACC6FF /* KeychainUtils.swift in Sources */,
 				48294CDE2AB936D9005E7CD2 /* SetProgressIntent.swift in Sources */,
+				94970573302BBA1D006A5D9B /* WriteReviewViewModel.swift in Sources */,
+				94970575302BBA1D006A5D9B /* WriteReviewView.swift in Sources */,
 				486354EB2B73437300A5DBB7 /* AiringText.swift in Sources */,
 				48643F452853C54800D7C328 /* ProfileViewModel.swift in Sources */,
 				48218AEE2BC0878D00A03421 /* MediaSort.swift in Sources */,

--- a/AniHyou/Queries/Review/DeleteReview.graphql
+++ b/AniHyou/Queries/Review/DeleteReview.graphql
@@ -1,0 +1,5 @@
+mutation DeleteReview($id: Int) {
+    DeleteReview(id: $id) {
+        deleted
+    }
+}

--- a/AniHyou/Queries/Review/SaveReview.graphql
+++ b/AniHyou/Queries/Review/SaveReview.graphql
@@ -1,0 +1,23 @@
+mutation SaveReview(
+    $id: Int,
+    $mediaId: Int!,
+    $body: String!,
+    $summary: String!,
+    $score: Int!,
+    $private: Boolean
+) {
+    SaveReview(
+        id: $id,
+        mediaId: $mediaId,
+        body: $body,
+        summary: $summary,
+        score: $score,
+        private: $private
+    ) {
+        id
+        summary
+        body(asHtml: false)
+        score
+        private
+    }
+}

--- a/AniHyou/Queries/Review/UserMediaReview.graphql
+++ b/AniHyou/Queries/Review/UserMediaReview.graphql
@@ -1,11 +1,9 @@
 query UserMediaReview($mediaId: Int, $userId: Int) {
-  Page(page: 1, perPage: 1) {
-    reviews(mediaId: $mediaId, userId: $userId) {
-      id
-      summary
-      body(asHtml: false)
-      score
-      private
-    }
+  Review(mediaId: $mediaId, userId: $userId) {
+    id
+    summary
+    body(asHtml: false)
+    score
+    private
   }
 }

--- a/AniHyou/Queries/Review/UserMediaReview.graphql
+++ b/AniHyou/Queries/Review/UserMediaReview.graphql
@@ -1,0 +1,11 @@
+query UserMediaReview($mediaId: Int, $userId: Int) {
+  Page(page: 1, perPage: 1) {
+    reviews(mediaId: $mediaId, userId: $userId) {
+      id
+      summary
+      body(asHtml: false)
+      score
+      private
+    }
+  }
+}

--- a/AniHyou/Repositories/ReviewRepository.swift
+++ b/AniHyou/Repositories/ReviewRepository.swift
@@ -22,13 +22,13 @@ struct ReviewRepository {
         }
     }
 
-    static func getUserReview(mediaId: Int32, userId: Int32) async -> UserMediaReviewQuery.Data.Page.Review? {
+    static func getUserReview(mediaId: Int32, userId: Int32) async -> UserMediaReviewQuery.Data.Review? {
         do {
             let result = try await Network.shared.apollo.fetch(
                 query: UserMediaReviewQuery(mediaId: .some(mediaId), userId: .some(userId)),
                 cachePolicy: .networkOnly
             )
-            return result.data?.page?.reviews?.first ?? nil
+            return result.data?.review
         } catch {
             print(error)
             return nil

--- a/AniHyou/Repositories/ReviewRepository.swift
+++ b/AniHyou/Repositories/ReviewRepository.swift
@@ -22,6 +22,33 @@ struct ReviewRepository {
         }
     }
     
+    // swiftlint:disable:next function_parameter_count
+    static func saveReview(
+        id: Int32?,
+        mediaId: Int32,
+        body: String,
+        summary: String,
+        score: Int32,
+        isPrivate: Bool
+    ) async -> Bool {
+        do {
+            let result = try await Network.shared.apollo.perform(
+                mutation: SaveReviewMutation(
+                    id: id.map { .some($0) } ?? .none,
+                    mediaId: mediaId,
+                    body: body,
+                    summary: summary,
+                    score: score,
+                    private: .some(isPrivate)
+                )
+            )
+            return result.data?.saveReview != nil
+        } catch {
+            print(error)
+            return false
+        }
+    }
+
     static func rateReview(
         reviewId: Int32,
         rating: ReviewRating

--- a/AniHyou/Repositories/ReviewRepository.swift
+++ b/AniHyou/Repositories/ReviewRepository.swift
@@ -9,7 +9,7 @@ import Foundation
 import AniListAPI
 
 struct ReviewRepository {
-    
+
     static func getReviewDetails(reviewId: Int32) async -> CommonReviewDetails? {
         do {
             let result = try await Network.shared.apollo.fetch(
@@ -21,7 +21,20 @@ struct ReviewRepository {
             return nil
         }
     }
-    
+
+    static func getUserReview(mediaId: Int32, userId: Int32) async -> UserMediaReviewQuery.Data.Page.Review? {
+        do {
+            let result = try await Network.shared.apollo.fetch(
+                query: UserMediaReviewQuery(mediaId: .some(mediaId), userId: .some(userId)),
+                cachePolicy: .networkOnly
+            )
+            return result.data?.page?.reviews?.first ?? nil
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+
     // swiftlint:disable:next function_parameter_count
     static func saveReview(
         id: Int32?,

--- a/AniHyou/Repositories/ReviewRepository.swift
+++ b/AniHyou/Repositories/ReviewRepository.swift
@@ -62,6 +62,18 @@ struct ReviewRepository {
         }
     }
 
+    static func deleteReview(id: Int32) async -> Bool {
+        do {
+            let result = try await Network.shared.apollo.perform(
+                mutation: DeleteReviewMutation(id: .some(id))
+            )
+            return result.data?.deleteReview?.deleted == true
+        } catch {
+            print(error)
+            return false
+        }
+    }
+
     static func rateReview(
         reviewId: Int32,
         rating: ReviewRating

--- a/AniHyou/Repositories/ReviewRepository.swift
+++ b/AniHyou/Repositories/ReviewRepository.swift
@@ -47,7 +47,7 @@ struct ReviewRepository {
         do {
             let result = try await Network.shared.apollo.perform(
                 mutation: SaveReviewMutation(
-                    id: id.map { .some($0) } ?? .none,
+                    id: someIfNotNil(id),
                     mediaId: mediaId,
                     body: body,
                     summary: summary,

--- a/AniHyou/Screens/MediaDetails/Edit/ViewModels/MediaListEditViewModel.swift
+++ b/AniHyou/Screens/MediaDetails/Edit/ViewModels/MediaListEditViewModel.swift
@@ -12,6 +12,15 @@ import AniListAPI
 @Observable class MediaListEditViewModel {
 
     var entry: BasicMediaListEntry?
+    var existingReview: UserMediaReviewQuery.Data.Page.Review?
+
+    func fetchExistingReview(mediaId: Int) async {
+        let userId = LoginRepository.authUserId()
+        existingReview = await ReviewRepository.getUserReview(
+            mediaId: Int32(mediaId),
+            userId: Int32(userId)
+        )
+    }
 
     var isLoading = false
 

--- a/AniHyou/Screens/MediaDetails/Edit/ViewModels/MediaListEditViewModel.swift
+++ b/AniHyou/Screens/MediaDetails/Edit/ViewModels/MediaListEditViewModel.swift
@@ -17,8 +17,8 @@ import AniListAPI
     func fetchExistingReview(mediaId: Int) async {
         let userId = LoginRepository.authUserId()
         existingReview = await ReviewRepository.getUserReview(
-            mediaId: Int32(mediaId),
-            userId: Int32(userId)
+            mediaId: mediaId.toInt32(),
+            userId: userId.toInt32()
         )
     }
 

--- a/AniHyou/Screens/MediaDetails/Edit/ViewModels/MediaListEditViewModel.swift
+++ b/AniHyou/Screens/MediaDetails/Edit/ViewModels/MediaListEditViewModel.swift
@@ -12,7 +12,7 @@ import AniListAPI
 @Observable class MediaListEditViewModel {
 
     var entry: BasicMediaListEntry?
-    var existingReview: UserMediaReviewQuery.Data.Page.Review?
+    var existingReview: UserMediaReviewQuery.Data.Review?
 
     func fetchExistingReview(mediaId: Int) async {
         let userId = LoginRepository.authUserId()

--- a/AniHyou/Screens/MediaDetails/Edit/Views/MediaListEditView.swift
+++ b/AniHyou/Screens/MediaDetails/Edit/Views/MediaListEditView.swift
@@ -35,6 +35,7 @@ struct MediaListEditView: View {
     @State private var isPrivate = false
     @State private var isHiddenFromStatusLists = false
     @State private var notes = ""
+    @State private var showWriteReview = false
     @State private var advancedScores: [String: Double] = [:]
     @State private var customLists: [String: Bool] = [:]
 
@@ -90,6 +91,9 @@ struct MediaListEditView: View {
                 Section {
                     TextField("Notes", text: $notes, axis: .vertical)
                         .lineLimit(5)
+                    Button("Write a Review") {
+                        showWriteReview = true
+                    }
                 }
                 
                 if advancedScoringEnabled == true {
@@ -116,6 +120,11 @@ struct MediaListEditView: View {
                 toolbarContent
             }//:Toolbar
         }//:NavigationStack
+        .sheet(isPresented: $showWriteReview) {
+            if let id = mediaDetails?.id {
+                WriteReviewView(mediaId: id)
+            }
+        }
         .onAppear {
             setValues()
         }

--- a/AniHyou/Screens/MediaDetails/Edit/Views/MediaListEditView.swift
+++ b/AniHyou/Screens/MediaDetails/Edit/Views/MediaListEditView.swift
@@ -91,7 +91,7 @@ struct MediaListEditView: View {
                 Section {
                     TextField("Notes", text: $notes, axis: .vertical)
                         .lineLimit(5)
-                    Button("Write a Review") {
+                    Button(viewModel.existingReview == nil ? "Write a Review" : "Edit Review") {
                         showWriteReview = true
                     }
                 }
@@ -122,11 +122,19 @@ struct MediaListEditView: View {
         }//:NavigationStack
         .sheet(isPresented: $showWriteReview) {
             if let id = mediaDetails?.id {
-                WriteReviewView(mediaId: id)
+                WriteReviewView(mediaId: id, existingReview: viewModel.existingReview)
+            }
+        }
+        .onChange(of: showWriteReview) {
+            if !showWriteReview, let id = mediaDetails?.id {
+                Task { await viewModel.fetchExistingReview(mediaId: id) }
             }
         }
         .onAppear {
             setValues()
+            if let id = mediaDetails?.id {
+                Task { await viewModel.fetchExistingReview(mediaId: id) }
+            }
         }
         .onChange(of: viewModel.isUpdateSuccess) {
             if viewModel.isUpdateSuccess, let entry = viewModel.entry {

--- a/AniHyou/Screens/ReviewDetails/ViewModels/WriteReviewViewModel.swift
+++ b/AniHyou/Screens/ReviewDetails/ViewModels/WriteReviewViewModel.swift
@@ -31,18 +31,18 @@ import Foundation
 
     func delete(id: Int) async {
         isSaving = true
-        deletedSuccessfully = await ReviewRepository.deleteReview(id: Int32(id))
+        deletedSuccessfully = await ReviewRepository.deleteReview(id: id.toInt32())
         isSaving = false
     }
 
     func save(id: Int?, mediaId: Int) async {
         isSaving = true
         let success = await ReviewRepository.saveReview(
-            id: id.map { Int32($0) },
-            mediaId: Int32(mediaId),
+            id: id.map { $0.toInt32() },
+            mediaId: mediaId.toInt32(),
             body: body,
             summary: summary,
-            score: Int32(score),
+            score: score.toInt32(),
             isPrivate: isPrivate
         )
         isSaving = false

--- a/AniHyou/Screens/ReviewDetails/ViewModels/WriteReviewViewModel.swift
+++ b/AniHyou/Screens/ReviewDetails/ViewModels/WriteReviewViewModel.swift
@@ -11,6 +11,7 @@ import Foundation
     var isSaving = false
     var saveError = false
     var savedSuccessfully = false
+    var deletedSuccessfully = false
 
     var summary = ""
     var body = ""
@@ -19,6 +20,12 @@ import Foundation
 
     var canSave: Bool {
         body.count >= 2600 && summary.count >= 20 && summary.count <= 120 && score > 0
+    }
+
+    func delete(id: Int) async {
+        isSaving = true
+        deletedSuccessfully = await ReviewRepository.deleteReview(id: Int32(id))
+        isSaving = false
     }
 
     func save(id: Int?, mediaId: Int) async {

--- a/AniHyou/Screens/ReviewDetails/ViewModels/WriteReviewViewModel.swift
+++ b/AniHyou/Screens/ReviewDetails/ViewModels/WriteReviewViewModel.swift
@@ -18,8 +18,15 @@ import Foundation
     var score = 0
     var isPrivate = false
 
+    static let minBodyLength = 2600
+    static let minSummaryLength = 20
+    static let maxSummaryLength = 120
+
     var canSave: Bool {
-        body.count >= 2600 && summary.count >= 20 && summary.count <= 120 && score > 0
+        body.count >= Self.minBodyLength
+            && summary.count >= Self.minSummaryLength
+            && summary.count <= Self.maxSummaryLength
+            && score > 0
     }
 
     func delete(id: Int) async {

--- a/AniHyou/Screens/ReviewDetails/ViewModels/WriteReviewViewModel.swift
+++ b/AniHyou/Screens/ReviewDetails/ViewModels/WriteReviewViewModel.swift
@@ -1,0 +1,41 @@
+//
+//  WriteReviewViewModel.swift
+//  AniHyou
+//
+
+import Foundation
+
+@MainActor
+@Observable class WriteReviewViewModel {
+
+    var isSaving = false
+    var saveError = false
+    var savedSuccessfully = false
+
+    var summary = ""
+    var body = ""
+    var score = 0
+    var isPrivate = false
+
+    var canSave: Bool {
+        body.count >= 2600 && summary.count >= 20 && summary.count <= 120 && score > 0
+    }
+
+    func save(id: Int?, mediaId: Int) async {
+        isSaving = true
+        let success = await ReviewRepository.saveReview(
+            id: id.map { Int32($0) },
+            mediaId: Int32(mediaId),
+            body: body,
+            summary: summary,
+            score: Int32(score),
+            isPrivate: isPrivate
+        )
+        isSaving = false
+        if success {
+            savedSuccessfully = true
+        } else {
+            saveError = true
+        }
+    }
+}

--- a/AniHyou/Screens/ReviewDetails/Views/WriteReviewView.swift
+++ b/AniHyou/Screens/ReviewDetails/Views/WriteReviewView.swift
@@ -43,10 +43,18 @@ struct WriteReviewView: View {
                     }
                 }
 
-                Section("Score (1–100)") {
-                    Stepper("\(viewModel.score)",
+                Section("Score") {
+                    HStack {
+                        TextField("0", value: $viewModel.score, formatter: NumberFormatter())
+                            .keyboardType(.numberPad)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 65)
+                        Stepper(
+                            "/100",
                             value: $viewModel.score,
-                            in: 0...100)
+                            in: 0...100
+                        )
+                    }
                 }
 
                 Section {

--- a/AniHyou/Screens/ReviewDetails/Views/WriteReviewView.swift
+++ b/AniHyou/Screens/ReviewDetails/Views/WriteReviewView.swift
@@ -10,7 +10,7 @@ struct WriteReviewView: View {
     @Environment(\.dismiss) private var dismiss
 
     let mediaId: Int
-    var existingReview: UserMediaReviewQuery.Data.Page.Review?
+    var existingReview: UserMediaReviewQuery.Data.Review?
 
     @State private var viewModel = WriteReviewViewModel()
     @State private var showDeleteDialog = false

--- a/AniHyou/Screens/ReviewDetails/Views/WriteReviewView.swift
+++ b/AniHyou/Screens/ReviewDetails/Views/WriteReviewView.swift
@@ -14,6 +14,7 @@ struct WriteReviewView: View {
 
     @State private var viewModel = WriteReviewViewModel()
     @State private var showDeleteDialog = false
+    private let textFieldWidth: CGFloat = 65
 
     var body: some View {
         NavigationStack {
@@ -24,7 +25,7 @@ struct WriteReviewView: View {
                 } header: {
                     Text("Summary")
                 } footer: {
-                    Text("\(viewModel.summary.count)/120, min 20")
+                    Text("\(viewModel.summary.count)/\(WriteReviewViewModel.maxSummaryLength), min \(WriteReviewViewModel.minSummaryLength)")
                         .foregroundStyle(.secondary)
                 }
 
@@ -34,8 +35,8 @@ struct WriteReviewView: View {
                 } header: {
                     Text("Review")
                 } footer: {
-                    if viewModel.body.count < 2600 {
-                        Text("\(2600 - viewModel.body.count) more characters required")
+                    if viewModel.body.count < WriteReviewViewModel.minBodyLength {
+                        Text("\(WriteReviewViewModel.minBodyLength - viewModel.body.count) more characters required")
                             .foregroundStyle(.secondary)
                     } else {
                         Text("\(viewModel.body.count) characters")
@@ -48,7 +49,7 @@ struct WriteReviewView: View {
                         TextField("0", value: $viewModel.score, formatter: NumberFormatter())
                             .keyboardType(.numberPad)
                             .textFieldStyle(.roundedBorder)
-                            .frame(width: 65)
+                            .frame(width: textFieldWidth)
                         Stepper(
                             "/100",
                             value: $viewModel.score,

--- a/AniHyou/Screens/ReviewDetails/Views/WriteReviewView.swift
+++ b/AniHyou/Screens/ReviewDetails/Views/WriteReviewView.swift
@@ -4,13 +4,16 @@
 //
 
 import SwiftUI
+import AniListAPI
 
 struct WriteReviewView: View {
     @Environment(\.dismiss) private var dismiss
 
     let mediaId: Int
+    var existingReview: UserMediaReviewQuery.Data.Page.Review?
 
     @State private var viewModel = WriteReviewViewModel()
+    @State private var showDeleteDialog = false
 
     var body: some View {
         NavigationStack {
@@ -49,8 +52,21 @@ struct WriteReviewView: View {
                 Section {
                     Toggle("Private", isOn: $viewModel.isPrivate)
                 }
+
+                if let id = existingReview?.id {
+                    Button("Delete Review", role: .destructive) {
+                        showDeleteDialog = true
+                    }
+                    .confirmationDialog("Delete this review?", isPresented: $showDeleteDialog) {
+                        Button("Delete", role: .destructive) {
+                            Task { await viewModel.delete(id: id) }
+                        }
+                    } message: {
+                        Text("Delete this review?")
+                    }
+                }
             }
-            .navigationTitle("Write Review")
+            .navigationTitle(existingReview == nil ? "Write Review" : "Edit Review")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
@@ -61,7 +77,7 @@ struct WriteReviewView: View {
                         ProgressView()
                     } else {
                         Button("Save") {
-                            Task { await viewModel.save(id: nil, mediaId: mediaId) }
+                            Task { await viewModel.save(id: existingReview?.id, mediaId: mediaId) }
                         }
                         .disabled(!viewModel.canSave)
                     }
@@ -72,6 +88,17 @@ struct WriteReviewView: View {
             }
             .onChange(of: viewModel.savedSuccessfully) {
                 if viewModel.savedSuccessfully { dismiss() }
+            }
+            .onChange(of: viewModel.deletedSuccessfully) {
+                if viewModel.deletedSuccessfully { dismiss() }
+            }
+            .onAppear {
+                if let review = existingReview {
+                    viewModel.summary = review.summary ?? ""
+                    viewModel.body = review.body ?? ""
+                    viewModel.score = review.score ?? 0
+                    viewModel.isPrivate = review.private ?? false
+                }
             }
         }
     }

--- a/AniHyou/Screens/ReviewDetails/Views/WriteReviewView.swift
+++ b/AniHyou/Screens/ReviewDetails/Views/WriteReviewView.swift
@@ -21,12 +21,19 @@ struct WriteReviewView: View {
             Form {
                 Section {
                     TextField("Summary", text: $viewModel.summary, axis: .vertical)
-                        .lineLimit(2...4)
+                        .lineLimit(1...4)
                 } header: {
                     Text("Summary")
                 } footer: {
-                    Text("\(viewModel.summary.count)/\(WriteReviewViewModel.maxSummaryLength), min \(WriteReviewViewModel.minSummaryLength)")
-                        .foregroundStyle(.secondary)
+                    HStack {
+                        Text("\(viewModel.summary.count)/\(WriteReviewViewModel.maxSummaryLength)")
+                            .foregroundStyle(.secondary)
+                        if viewModel.summary.count < WriteReviewViewModel.minSummaryLength {
+                            let requiredCount = WriteReviewViewModel.minSummaryLength - viewModel.summary.count
+                            Text("\(requiredCount) more characters required")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
                 }
 
                 Section {

--- a/AniHyou/Screens/ReviewDetails/Views/WriteReviewView.swift
+++ b/AniHyou/Screens/ReviewDetails/Views/WriteReviewView.swift
@@ -1,0 +1,78 @@
+//
+//  WriteReviewView.swift
+//  AniHyou
+//
+
+import SwiftUI
+
+struct WriteReviewView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let mediaId: Int
+
+    @State private var viewModel = WriteReviewViewModel()
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Summary", text: $viewModel.summary, axis: .vertical)
+                        .lineLimit(2...4)
+                } header: {
+                    Text("Summary")
+                } footer: {
+                    Text("\(viewModel.summary.count)/120, min 20")
+                        .foregroundStyle(.secondary)
+                }
+
+                Section {
+                    TextEditor(text: $viewModel.body)
+                        .frame(minHeight: 200)
+                } header: {
+                    Text("Review")
+                } footer: {
+                    if viewModel.body.count < 2600 {
+                        Text("\(2600 - viewModel.body.count) more characters required")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("\(viewModel.body.count) characters")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Section("Score (1–100)") {
+                    Stepper("\(viewModel.score)",
+                            value: $viewModel.score,
+                            in: 0...100)
+                }
+
+                Section {
+                    Toggle("Private", isOn: $viewModel.isPrivate)
+                }
+            }
+            .navigationTitle("Write Review")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if viewModel.isSaving {
+                        ProgressView()
+                    } else {
+                        Button("Save") {
+                            Task { await viewModel.save(id: nil, mediaId: mediaId) }
+                        }
+                        .disabled(!viewModel.canSave)
+                    }
+                }
+            }
+            .alert("Error", isPresented: $viewModel.saveError) {
+                Button("OK", role: .cancel) {}
+            }
+            .onChange(of: viewModel.savedSuccessfully) {
+                if viewModel.savedSuccessfully { dismiss() }
+            }
+        }
+    }
+}

--- a/AniListAPI/Sources/Operations/Mutations/DeleteReviewMutation.graphql.swift
+++ b/AniListAPI/Sources/Operations/Mutations/DeleteReviewMutation.graphql.swift
@@ -1,0 +1,57 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+@_spi(Execution) @_spi(Unsafe) import ApolloAPI
+
+nonisolated public struct DeleteReviewMutation: GraphQLMutation {
+  public static let operationName: String = "DeleteReview"
+  public static let operationDocument: ApolloAPI.OperationDocument = .init(
+    definition: .init(
+      #"mutation DeleteReview($id: Int) { DeleteReview(id: $id) { __typename deleted } }"#
+    ))
+
+  public var id: GraphQLNullable<Int32>
+
+  public init(id: GraphQLNullable<Int32>) {
+    self.id = id
+  }
+
+  @_spi(Unsafe) public var __variables: Variables? { ["id": id] }
+
+  nonisolated public struct Data: AniListAPI.SelectionSet {
+    @_spi(Unsafe) public let __data: DataDict
+    @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
+
+    @_spi(Execution) public static var __parentType: any ApolloAPI.ParentType { AniListAPI.Objects.Mutation }
+    @_spi(Execution) public static var __selections: [ApolloAPI.Selection] { [
+      .field("DeleteReview", DeleteReview?.self, arguments: ["id": .variable("id")]),
+    ] }
+    @_spi(Execution) public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+      DeleteReviewMutation.Data.self
+    ] }
+
+    /// Delete a review
+    public var deleteReview: DeleteReview? { __data["DeleteReview"] }
+
+    /// DeleteReview
+    ///
+    /// Parent Type: `Deleted`
+    nonisolated public struct DeleteReview: AniListAPI.SelectionSet {
+      @_spi(Unsafe) public let __data: DataDict
+      @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
+
+      @_spi(Execution) public static var __parentType: any ApolloAPI.ParentType { AniListAPI.Objects.Deleted }
+      @_spi(Execution) public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
+        .field("deleted", Bool?.self),
+      ] }
+      @_spi(Execution) public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+        DeleteReviewMutation.Data.DeleteReview.self
+      ] }
+
+      /// If an item has been successfully deleted
+      public var deleted: Bool? { __data["deleted"] }
+    }
+  }
+}

--- a/AniListAPI/Sources/Operations/Mutations/SaveReviewMutation.graphql.swift
+++ b/AniListAPI/Sources/Operations/Mutations/SaveReviewMutation.graphql.swift
@@ -1,0 +1,100 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+@_spi(Execution) @_spi(Unsafe) import ApolloAPI
+
+nonisolated public struct SaveReviewMutation: GraphQLMutation {
+  public static let operationName: String = "SaveReview"
+  public static let operationDocument: ApolloAPI.OperationDocument = .init(
+    definition: .init(
+      #"mutation SaveReview($id: Int, $mediaId: Int!, $body: String!, $summary: String!, $score: Int!, $private: Boolean) { SaveReview( id: $id mediaId: $mediaId body: $body summary: $summary score: $score private: $private ) { __typename id summary body(asHtml: false) score private } }"#
+    ))
+
+  public var id: GraphQLNullable<Int32>
+  public var mediaId: Int32
+  public var body: String
+  public var summary: String
+  public var score: Int32
+  public var `private`: GraphQLNullable<Bool>
+
+  public init(
+    id: GraphQLNullable<Int32>,
+    mediaId: Int32,
+    body: String,
+    summary: String,
+    score: Int32,
+    `private`: GraphQLNullable<Bool>
+  ) {
+    self.id = id
+    self.mediaId = mediaId
+    self.body = body
+    self.summary = summary
+    self.score = score
+    self.`private` = `private`
+  }
+
+  @_spi(Unsafe) public var __variables: Variables? { [
+    "id": id,
+    "mediaId": mediaId,
+    "body": body,
+    "summary": summary,
+    "score": score,
+    "private": `private`
+  ] }
+
+  nonisolated public struct Data: AniListAPI.SelectionSet {
+    @_spi(Unsafe) public let __data: DataDict
+    @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
+
+    @_spi(Execution) public static var __parentType: any ApolloAPI.ParentType { AniListAPI.Objects.Mutation }
+    @_spi(Execution) public static var __selections: [ApolloAPI.Selection] { [
+      .field("SaveReview", SaveReview?.self, arguments: [
+        "id": .variable("id"),
+        "mediaId": .variable("mediaId"),
+        "body": .variable("body"),
+        "summary": .variable("summary"),
+        "score": .variable("score"),
+        "private": .variable("private")
+      ]),
+    ] }
+    @_spi(Execution) public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+      SaveReviewMutation.Data.self
+    ] }
+
+    /// Create or update a review
+    public var saveReview: SaveReview? { __data["SaveReview"] }
+
+    /// SaveReview
+    ///
+    /// Parent Type: `Review`
+    nonisolated public struct SaveReview: AniListAPI.SelectionSet {
+      @_spi(Unsafe) public let __data: DataDict
+      @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
+
+      @_spi(Execution) public static var __parentType: any ApolloAPI.ParentType { AniListAPI.Objects.Review }
+      @_spi(Execution) public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
+        .field("id", Int.self),
+        .field("summary", String?.self),
+        .field("body", String?.self, arguments: ["asHtml": false]),
+        .field("score", Int?.self),
+        .field("private", Bool?.self),
+      ] }
+      @_spi(Execution) public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+        SaveReviewMutation.Data.SaveReview.self
+      ] }
+
+      /// The id of the review
+      public var id: Int { __data["id"] }
+      /// A short summary of the review
+      public var summary: String? { __data["summary"] }
+      /// The main review body text
+      public var body: String? { __data["body"] }
+      /// The review score of the media
+      public var score: Int? { __data["score"] }
+      /// If the review is not yet publicly published and is only viewable by creator
+      public var `private`: Bool? { __data["private"] }
+    }
+  }
+}

--- a/AniListAPI/Sources/Operations/Queries/UserMediaReviewQuery.graphql.swift
+++ b/AniListAPI/Sources/Operations/Queries/UserMediaReviewQuery.graphql.swift
@@ -1,0 +1,101 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+@_spi(Execution) @_spi(Unsafe) import ApolloAPI
+
+nonisolated public struct UserMediaReviewQuery: GraphQLQuery {
+  public static let operationName: String = "UserMediaReview"
+  public static let operationDocument: ApolloAPI.OperationDocument = .init(
+    definition: .init(
+      #"query UserMediaReview($mediaId: Int, $userId: Int) { Page(page: 1, perPage: 1) { __typename reviews(mediaId: $mediaId, userId: $userId) { __typename id summary body(asHtml: false) score private } } }"#
+    ))
+
+  public var mediaId: GraphQLNullable<Int32>
+  public var userId: GraphQLNullable<Int32>
+
+  public init(
+    mediaId: GraphQLNullable<Int32>,
+    userId: GraphQLNullable<Int32>
+  ) {
+    self.mediaId = mediaId
+    self.userId = userId
+  }
+
+  @_spi(Unsafe) public var __variables: Variables? { [
+    "mediaId": mediaId,
+    "userId": userId
+  ] }
+
+  nonisolated public struct Data: AniListAPI.SelectionSet {
+    @_spi(Unsafe) public let __data: DataDict
+    @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
+
+    @_spi(Execution) public static var __parentType: any ApolloAPI.ParentType { AniListAPI.Objects.Query }
+    @_spi(Execution) public static var __selections: [ApolloAPI.Selection] { [
+      .field("Page", Page?.self, arguments: [
+        "page": 1,
+        "perPage": 1
+      ]),
+    ] }
+    @_spi(Execution) public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+      UserMediaReviewQuery.Data.self
+    ] }
+
+    public var page: Page? { __data["Page"] }
+
+    /// Page
+    ///
+    /// Parent Type: `Page`
+    nonisolated public struct Page: AniListAPI.SelectionSet {
+      @_spi(Unsafe) public let __data: DataDict
+      @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
+
+      @_spi(Execution) public static var __parentType: any ApolloAPI.ParentType { AniListAPI.Objects.Page }
+      @_spi(Execution) public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
+        .field("reviews", [Review?]?.self, arguments: [
+          "mediaId": .variable("mediaId"),
+          "userId": .variable("userId")
+        ]),
+      ] }
+      @_spi(Execution) public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+        UserMediaReviewQuery.Data.Page.self
+      ] }
+
+      public var reviews: [Review?]? { __data["reviews"] }
+
+      /// Page.Review
+      ///
+      /// Parent Type: `Review`
+      nonisolated public struct Review: AniListAPI.SelectionSet {
+        @_spi(Unsafe) public let __data: DataDict
+        @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
+
+        @_spi(Execution) public static var __parentType: any ApolloAPI.ParentType { AniListAPI.Objects.Review }
+        @_spi(Execution) public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
+          .field("id", Int.self),
+          .field("summary", String?.self),
+          .field("body", String?.self, arguments: ["asHtml": false]),
+          .field("score", Int?.self),
+          .field("private", Bool?.self),
+        ] }
+        @_spi(Execution) public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+          UserMediaReviewQuery.Data.Page.Review.self
+        ] }
+
+        /// The id of the review
+        public var id: Int { __data["id"] }
+        /// A short summary of the review
+        public var summary: String? { __data["summary"] }
+        /// The main review body text
+        public var body: String? { __data["body"] }
+        /// The review score of the media
+        public var score: Int? { __data["score"] }
+        /// If the review is not yet publicly published and is only viewable by creator
+        public var `private`: Bool? { __data["private"] }
+      }
+    }
+  }
+}

--- a/AniListAPI/Sources/Operations/Queries/UserMediaReviewQuery.graphql.swift
+++ b/AniListAPI/Sources/Operations/Queries/UserMediaReviewQuery.graphql.swift
@@ -8,7 +8,7 @@ nonisolated public struct UserMediaReviewQuery: GraphQLQuery {
   public static let operationName: String = "UserMediaReview"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"query UserMediaReview($mediaId: Int, $userId: Int) { Page(page: 1, perPage: 1) { __typename reviews(mediaId: $mediaId, userId: $userId) { __typename id summary body(asHtml: false) score private } } }"#
+      #"query UserMediaReview($mediaId: Int, $userId: Int) { Review(mediaId: $mediaId, userId: $userId) { __typename id summary body(asHtml: false) score private } }"#
     ))
 
   public var mediaId: GraphQLNullable<Int32>
@@ -33,69 +33,48 @@ nonisolated public struct UserMediaReviewQuery: GraphQLQuery {
 
     @_spi(Execution) public static var __parentType: any ApolloAPI.ParentType { AniListAPI.Objects.Query }
     @_spi(Execution) public static var __selections: [ApolloAPI.Selection] { [
-      .field("Page", Page?.self, arguments: [
-        "page": 1,
-        "perPage": 1
+      .field("Review", Review?.self, arguments: [
+        "mediaId": .variable("mediaId"),
+        "userId": .variable("userId")
       ]),
     ] }
     @_spi(Execution) public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
       UserMediaReviewQuery.Data.self
     ] }
 
-    public var page: Page? { __data["Page"] }
+    /// Review query
+    public var review: Review? { __data["Review"] }
 
-    /// Page
+    /// Review
     ///
-    /// Parent Type: `Page`
-    nonisolated public struct Page: AniListAPI.SelectionSet {
+    /// Parent Type: `Review`
+    nonisolated public struct Review: AniListAPI.SelectionSet {
       @_spi(Unsafe) public let __data: DataDict
       @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
 
-      @_spi(Execution) public static var __parentType: any ApolloAPI.ParentType { AniListAPI.Objects.Page }
+      @_spi(Execution) public static var __parentType: any ApolloAPI.ParentType { AniListAPI.Objects.Review }
       @_spi(Execution) public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
-        .field("reviews", [Review?]?.self, arguments: [
-          "mediaId": .variable("mediaId"),
-          "userId": .variable("userId")
-        ]),
+        .field("id", Int.self),
+        .field("summary", String?.self),
+        .field("body", String?.self, arguments: ["asHtml": false]),
+        .field("score", Int?.self),
+        .field("private", Bool?.self),
       ] }
       @_spi(Execution) public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
-        UserMediaReviewQuery.Data.Page.self
+        UserMediaReviewQuery.Data.Review.self
       ] }
 
-      public var reviews: [Review?]? { __data["reviews"] }
-
-      /// Page.Review
-      ///
-      /// Parent Type: `Review`
-      nonisolated public struct Review: AniListAPI.SelectionSet {
-        @_spi(Unsafe) public let __data: DataDict
-        @_spi(Unsafe) public init(_dataDict: DataDict) { __data = _dataDict }
-
-        @_spi(Execution) public static var __parentType: any ApolloAPI.ParentType { AniListAPI.Objects.Review }
-        @_spi(Execution) public static var __selections: [ApolloAPI.Selection] { [
-          .field("__typename", String.self),
-          .field("id", Int.self),
-          .field("summary", String?.self),
-          .field("body", String?.self, arguments: ["asHtml": false]),
-          .field("score", Int?.self),
-          .field("private", Bool?.self),
-        ] }
-        @_spi(Execution) public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
-          UserMediaReviewQuery.Data.Page.Review.self
-        ] }
-
-        /// The id of the review
-        public var id: Int { __data["id"] }
-        /// A short summary of the review
-        public var summary: String? { __data["summary"] }
-        /// The main review body text
-        public var body: String? { __data["body"] }
-        /// The review score of the media
-        public var score: Int? { __data["score"] }
-        /// If the review is not yet publicly published and is only viewable by creator
-        public var `private`: Bool? { __data["private"] }
-      }
+      /// The id of the review
+      public var id: Int { __data["id"] }
+      /// A short summary of the review
+      public var summary: String? { __data["summary"] }
+      /// The main review body text
+      public var body: String? { __data["body"] }
+      /// The review score of the media
+      public var score: Int? { __data["score"] }
+      /// If the review is not yet publicly published and is only viewable by creator
+      public var `private`: Bool? { __data["private"] }
     }
   }
 }


### PR DESCRIPTION
# Write Reviews in App

Completes #54 by adding the ability to write, edit, and delete AniList reviews directly from the media list entry sheet

## Summary
- Added a "Write a Review" button in the Notes section of the edit sheet; if the user already has a review for that media it shows "Edit Review" and pre-populates the form
- The write/edit sheet includes a summary field, a long-form body (2600 char minimum enforced per AniList), a score input, and a private toggle
- Deleting a review requires confirmation and is only available when editing an existing review
- Uses new SaveReview, DeleteReview, and UserMediaReview GraphQL operations; always fetches review state fresh from the network to avoid stale cache

### Screenshots

<img width="196.6666666667" height="426" alt="IMG_0239" src="https://github.com/user-attachments/assets/1e4b1a51-9528-4485-8ee2-e36dcfe9d5ac" />
<img width="196.6666666667" height="426" alt="IMG_0240" src="https://github.com/user-attachments/assets/5d6b774f-586e-4fe1-b2f1-3324f100b751" />
<img width="196.6666666667" height="426" alt="IMG_0241" src="https://github.com/user-attachments/assets/d12a5447-170f-4a61-a1fa-5bf8be3788d2" />
<img width="196.6666666667" height="426" alt="IMG_0242" src="https://github.com/user-attachments/assets/34432969-9e2d-4149-9062-817f4e78291d" />
